### PR TITLE
Fix couple of issues in the app

### DIFF
--- a/YourJourney/Assets/Scripts/Engine/Managers/ObjectiveManager.cs
+++ b/YourJourney/Assets/Scripts/Engine/Managers/ObjectiveManager.cs
@@ -105,7 +105,7 @@ public class ObjectiveManager : MonoBehaviour
 	{
 		if ( currentObjective == null )
 			return false;
-		Debug.Log( "TryCompleteObjective: " + name );
+		Debug.Log( "TryCompleteObjective: " + triggername);
 
 		//objective is complete, remove it and fire any on complete trigger
 		//TODO - show completion textbox?  show lore earned?
@@ -120,7 +120,7 @@ public class ObjectiveManager : MonoBehaviour
 			return true;
 		}
 
-		Debug.Log( "TryCompleteObjective NOT FOUND: " + name );
+		Debug.Log( "TryCompleteObjective NOT FOUND: " + triggername);
 		return false;
 	}
 

--- a/YourJourney/Assets/Scripts/Engine/Managers/TriggerManager.cs
+++ b/YourJourney/Assets/Scripts/Engine/Managers/TriggerManager.cs
@@ -199,7 +199,7 @@ public class TriggerManager : MonoBehaviour
 			}
 			yield return WaitUntilFinished();
 
-			if ( trigger.dataName == endTriggerGUID )
+			if ( trigger.dataName == endTriggerGUID && endTriggerGUID?.Length > 0)
 			{
 				Debug.Log( "Triggering End Scenario" );
 				engine.EndScenario( trigger.triggerName );

--- a/YourJourney/Assets/Scripts/Engine/Managers/TriggerManager.cs
+++ b/YourJourney/Assets/Scripts/Engine/Managers/TriggerManager.cs
@@ -199,7 +199,7 @@ public class TriggerManager : MonoBehaviour
 			}
 			yield return WaitUntilFinished();
 
-			if ( trigger.dataName == endTriggerGUID && endTriggerGUID?.Length > 0)
+			if ( trigger.dataName == endTriggerGUID && !string.IsNullOrEmpty(endTriggerGUID))
 			{
 				Debug.Log( "Triggering End Scenario" );
 				engine.EndScenario( trigger.triggerName );


### PR DESCRIPTION
- ObjectiveManager TryCompleteObjective printed out MonoBehavior name instead of triggername
- TriggerManager.TriggerChain always triggered the End Scenario if it was called with a trigger that could not be found from any of the trigger lists (creating a trigger with no dataName whilst endTriggerGuid being also empty. Added a safeguard that it won't trigger end scenario unless the endTriggerGUID has some value.