### PR TITLE
Removed out-of-bounds anchor in Tile 301A causing tile displacement

### DIFF
--- a/YourJourney/Assets/Prefabs/A/T301A.prefab
+++ b/YourJourney/Assets/Prefabs/A/T301A.prefab
@@ -151,7 +151,6 @@ Transform:
   - {fileID: 4036360687662257541}
   - {fileID: 6137156028171964522}
   - {fileID: 130445831437475310}
-  - {fileID: 165745541993824199}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5592,36 +5591,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 15366712624692150}
   m_RootOrder: 28
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5933476014173601298
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 165745541993824199}
-  m_Layer: 0
-  m_Name: anchor3 (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 4422084297763085224, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &165745541993824199
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5933476014173601298}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 115, y: 0, z: 1.299038}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 15366712624692150}
-  m_RootOrder: 33
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6193513365612467172
 GameObject:


### PR DESCRIPTION
The group center was getting averaged with an anchor that was at X position 115, causing any Tile Group with tile 301A in it to be way off the normal map, making it look like the original map had disappeared. I tried searching for similar displacements in other tiles via regex on their prefabs and didn't find anything.